### PR TITLE
Rename build-image.sh script and adjust image name

### DIFF
--- a/build-image.sh
+++ b/build-image.sh
@@ -6,4 +6,4 @@ cp target/microserve-users-1.0.0.jar ../topology/users-image/
 
 cd ../topology
 
-docker build --rm -t users-image users-image
+docker build --rm -t pestakit/users users-image


### PR DESCRIPTION
I have renamed the script that builds the image and corrected the name of the docker image, so that it is consistent across micro-services.